### PR TITLE
Lifecycle improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,25 @@ The file always contains:
 | `jobName` | The AWS Batch job name |
 | `outputPath` | The full S3 key prefix for this job's outputs |
 | `completedAt` | ISO 8601 UTC timestamp of job completion |
-| `status` | `"SUCCESS"` or `"FAILED"` |
+| `status` | `"success"` or `"failed"` |
 
 Additional fields can be injected at submission time by setting the `RUN_METADATA_EXTRA` environment variable (via container overrides) to a JSON fragment — comma-separated `"key": "value"` pairs without the enclosing braces:
 
 ```bash
 RUN_METADATA_EXTRA='"triggeredBy": "alice", "githubRunId": "12345"'
 ```
+
+## S3 Buckets
+
+By default, the deployment creates two S3 buckets (input and output) and manages their configuration — including lifecycle rules — via CloudFormation. Re-running the deploy script on an existing setup is safe: CloudFormation updates bucket properties in-place without recreating them or affecting stored data.
+
+If you want to bring your own pre-existing buckets and have CDK reference them without managing their configuration, set the `useExistingBuckets` context flag:
+
+```bash
+cdk deploy --all --context useExistingBuckets=true
+```
+
+When this flag is set, CDK imports the buckets by their expected names and does not create or modify them. Lifecycle rules and other bucket properties will not be applied.
 
 ## Automatic Cleanup of Failed Runs
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ AWS batch job will be printed to the console. The output will be synced to your 
 * `cdk diff`        compare deployed stack with current state
 * `cdk docs`        open CDK documentation
 
+## Run Metadata
+
+At the end of each job, `run.sh` writes a `_run_metadata.json` file to the job's S3 output prefix:
+
+```
+s3://{output-bucket}/{OUTPUT_SCENARIO}/{JOB_NAME}/_run_metadata.json
+```
+
+The file always contains:
+
+| Field | Value |
+|---|---|
+| `jobName` | The AWS Batch job name |
+| `outputPath` | The full S3 key prefix for this job's outputs |
+| `completedAt` | ISO 8601 UTC timestamp of job completion |
+| `status` | `"SUCCESS"` or `"FAILED"` |
+
+Additional fields can be injected at submission time by setting the `RUN_METADATA_EXTRA` environment variable (via container overrides) to a JSON fragment — comma-separated `"key": "value"` pairs without the enclosing braces:
+
+```bash
+RUN_METADATA_EXTRA='"triggeredBy": "alice", "githubRunId": "12345"'
+```
+
+## Automatic Cleanup of Failed Runs
+
+The output S3 bucket includes a lifecycle rule (`DeleteFailedSimulationOutputs`) that automatically deletes the outputs of failed simulation runs. When a job exits with a non-zero code, `run.sh` tags every object in the job's output prefix with `SimulationStatus=failed`. The lifecycle rule deletes all tagged objects after a configurable retention period.
+
+Configure the retention period at deploy time:
+
+```bash
+cdk deploy --context failedRunRetentionDays=14   # default: 7
+```
+
 
 # DISCLAIMER:
 The code is provided as is. There is no warranty about 

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -57,6 +57,14 @@ for directory in "${INPUT_DIRECTORIES_ARRAY[@]}"; do
   aws s3 sync --only-show-errors "s3://${JOB_INPUT_BUCKET}/${directory}" "./${directory}"
 done
 
+# Per-file input copying (INPUT_FILES is a comma-separated list of S3-relative paths)
+IFS=',' read -r -a INPUT_FILES_ARRAY <<< "${INPUT_FILES:-}"
+for file in "${INPUT_FILES_ARRAY[@]}"; do
+    [[ -z "$file" ]] && continue
+    mkdir -p "$(dirname "${file}")"
+    aws s3 cp --only-show-errors "s3://${JOB_INPUT_BUCKET}/${file}" "./${file}"
+done
+
 
 # assume JAR_NAME="io/moia/a.jar:io/moia/b.jar:other/x.jar"
 IFS=':' read -r -a remote_jars <<< "$JAR_NAME"

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -95,6 +95,7 @@ echo "$@" > "${OUTPUT_DIR}/matsim_parameters.txt"
 aws s3 sync --only-show-errors "${OUTPUT_DIR}" "${SYNC_PATH}"
 
 
+set +e
 if [ -z ${AWS_BATCH_JOB_ARRAY_INDEX+x} ]; then
     echo "Single batch job"
     java -XX:+UseParallelGC \
@@ -115,9 +116,52 @@ else
       --batch-job-array-index "${AWS_BATCH_JOB_ARRAY_INDEX}" "$@"
 fi
 # we are using the traditional parallel GC - for noninteractive applications i.e. pure throughput it's still the best
+RET=$?
+set -e
 
+if [ "${RET}" -eq 0 ]; then STATUS="SUCCESS"; else STATUS="FAILED"; fi
+
+mkdir -p /tmp/output
+EXTRA_FIELDS=""
+if [ -n "${RUN_METADATA_EXTRA:-}" ]; then
+    EXTRA_FIELDS=", ${RUN_METADATA_EXTRA}"
+fi
+cat > /tmp/output/_run_metadata.json <<EOF
+{
+  "jobName": "${JOB_NAME}",
+  "outputPath": "${OUTPUT_SCENARIO}/${JOB_NAME}",
+  "completedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "status": "${STATUS}"${EXTRA_FIELDS}
+}
+EOF
 
 aws s3 sync --only-show-errors "${OUTPUT_DIR}" "${SYNC_PATH}"
+
+# Lowercase the status for use as an S3 tag value
+STATUS_TAG=$(echo "${STATUS}" | tr '[:upper:]' '[:lower:]')
+
+# Sentinel tag on _run_metadata.json (immediate observability, one API call)
+aws s3api put-object-tagging \
+    --bucket "${JOB_OUTPUT_BUCKET}" \
+    --key "${OUTPUT_SCENARIO}/${JOB_NAME}/_run_metadata.json" \
+    --tagging "TagSet=[{Key=SimulationStatus,Value=${STATUS_TAG}}]"
+
+# Bulk-tag all output objects (for lifecycle rule storage cleanup, failed runs only)
+if [ "${STATUS}" = "FAILED" ]; then
+    aws s3api list-objects-v2 \
+        --bucket "${JOB_OUTPUT_BUCKET}" \
+        --prefix "${OUTPUT_SCENARIO}/${JOB_NAME}/" \
+        --query "Contents[].Key" \
+        --output text \
+    | tr '\t' '\n' \
+    | while read -r key; do
+        [[ -z "$key" ]] && continue
+        aws s3api put-object-tagging \
+            --bucket "${JOB_OUTPUT_BUCKET}" \
+            --key "${key}" \
+            --tagging "TagSet=[{Key=SimulationStatus,Value=failed}]"
+      done
+fi
 
 # make sure a full sync cycle was completed before we end the job
 while [ "${MATSIM_DONE_SEMAPHORE}" -nt "${SYNC_SEMAPHORE}" ]; do

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -147,7 +147,7 @@ fi
 RET=$?
 set -e
 
-if [ "${RET}" -eq 0 ]; then STATUS="SUCCESS"; else STATUS="FAILED"; fi
+if [ "${RET}" -eq 0 ]; then STATUS="success"; else STATUS="failed"; fi
 
 mkdir -p /tmp/output
 EXTRA_FIELDS=""
@@ -166,17 +166,14 @@ EOF
 
 aws s3 sync --only-show-errors "${OUTPUT_DIR}" "${SYNC_PATH}"
 
-# Lowercase the status for use as an S3 tag value
-STATUS_TAG=$(echo "${STATUS}" | tr '[:upper:]' '[:lower:]')
-
 # Sentinel tag on _run_metadata.json (immediate observability, one API call)
 aws s3api put-object-tagging \
     --bucket "${JOB_OUTPUT_BUCKET}" \
     --key "${OUTPUT_SCENARIO}/${JOB_NAME}/_run_metadata.json" \
-    --tagging "TagSet=[{Key=SimulationStatus,Value=${STATUS_TAG}}]"
+    --tagging "TagSet=[{Key=SimulationStatus,Value=${STATUS}}]"
 
 # Bulk-tag all output objects (for lifecycle rule storage cleanup, failed runs only)
-if [ "${STATUS}" = "FAILED" ]; then
+if [ "${STATUS}" = "failed" ]; then
     aws s3api list-objects-v2 \
         --bucket "${JOB_OUTPUT_BUCKET}" \
         --prefix "${OUTPUT_SCENARIO}/${JOB_NAME}/" \

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -131,7 +131,9 @@ cat > /tmp/output/_run_metadata.json <<EOF
   "jobName": "${JOB_NAME}",
   "outputPath": "${OUTPUT_SCENARIO}/${JOB_NAME}",
   "completedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "status": "${STATUS}"${EXTRA_FIELDS}
+  "status": "${STATUS}",
+  "inputFiles": "${INPUT_FILES:-}",
+  "inputDirectories": "${INPUT_DIRECTORIES:-}"${EXTRA_FIELDS}
 }
 EOF
 

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -10,9 +10,6 @@ JOB_INPUT_BUCKET="${JOB_INPUT_BUCKET}"
 JOB_OUTPUT_BUCKET="${JOB_OUTPUT_BUCKET}"
 
 
-# Read comma-separated input directories into an array
-IFS=',' read -r -a INPUT_DIRECTORIES_ARRAY <<< "${INPUT_DIRECTORIES}"
-
 
 if [ -z ${JOB_INPUT_BUCKET+x} ]; then
     echo "You need to specify a 'JOB_INPUT_BUCKET' environment variable (either in job definition or actual job)"
@@ -51,18 +48,49 @@ cd "${SCRIPT_DIR}/"
 
 echo "${SCRIPT_DIR}"
 
-# sync all input directories
-for directory in "${INPUT_DIRECTORIES_ARRAY[@]}"; do
-  echo "Syncing from:" "s3://${JOB_INPUT_BUCKET}/${directory}"
-  aws s3 sync --only-show-errors "s3://${JOB_INPUT_BUCKET}/${directory}" "./${directory}"
-done
+# Resolve a path entry to a full S3 URI: pass through if already s3://, else prepend input bucket.
+resolve_s3_uri() {
+  local entry="$1"
+  if [[ "$entry" == s3://* ]]; then
+    echo "$entry"
+  else
+    echo "s3://${JOB_INPUT_BUCKET}/${entry}"
+  fi
+}
 
-# Per-file input copying (INPUT_FILES is a comma-separated list of S3-relative paths)
-IFS=',' read -r -a INPUT_FILES_ARRAY <<< "${INPUT_FILES:-}"
-for file in "${INPUT_FILES_ARRAY[@]}"; do
-    [[ -z "$file" ]] && continue
-    mkdir -p "$(dirname "${file}")"
-    aws s3 cp --only-show-errors "s3://${JOB_INPUT_BUCKET}/${file}" "./${file}"
+# Strip s3://bucket-name/ to obtain the local relative path.
+# e.g. s3://matsim-jobs-input-123456789/examples/equil/ -> examples/equil/
+s3_uri_to_local_path() {
+  local without_scheme="${1#s3://}"   # strip "s3://"
+  echo "${without_scheme#*/}"         # strip "bucket-name/"
+}
+
+# Fetch all input paths.
+# Each entry is either a relative path (resolved against JOB_INPUT_BUCKET) or a full s3:// URI.
+# Trailing slash forces directory sync; otherwise auto-detects file vs. prefix via head-object.
+IFS=',' read -r -a INPUT_PATHS_ARRAY <<< "${INPUT_PATHS:-}"
+for entry in "${INPUT_PATHS_ARRAY[@]}"; do
+  [[ -z "$entry" ]] && continue
+  uri=$(resolve_s3_uri "$entry")
+  local_path=$(s3_uri_to_local_path "$uri")
+  if [[ "$entry" == */ ]]; then
+    echo "Syncing directory from: ${uri}"
+    mkdir -p "./${local_path}"
+    aws s3 sync --only-show-errors "$uri" "./${local_path}"
+  else
+    without_scheme="${uri#s3://}"
+    bucket="${without_scheme%%/*}"
+    key="${without_scheme#*/}"
+    if aws s3api head-object --bucket "$bucket" --key "$key" > /dev/null 2>&1; then
+      echo "Copying file from: ${uri}"
+      mkdir -p "$(dirname "./${local_path}")"
+      aws s3 cp --only-show-errors "$uri" "./${local_path}"
+    else
+      echo "Syncing directory from: ${uri}"
+      mkdir -p "./${local_path}"
+      aws s3 sync --only-show-errors "$uri" "./${local_path}"
+    fi
+  fi
 done
 
 
@@ -132,8 +160,7 @@ cat > /tmp/output/_run_metadata.json <<EOF
   "outputPath": "${OUTPUT_SCENARIO}/${JOB_NAME}",
   "completedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "status": "${STATUS}",
-  "inputFiles": "${INPUT_FILES:-}",
-  "inputDirectories": "${INPUT_DIRECTORIES:-}"${EXTRA_FIELDS}
+  "inputPaths": "${INPUT_PATHS:-}"${EXTRA_FIELDS}
 }
 EOF
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,0 @@
-jdk:
-  - openjdk21
-install:
-  - mvn install -f matsim-aws-setup/pom.xml -DskipTests --no-transfer-progress

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+jdk:
+  - openjdk21
+build:
+  - cd matsim-aws-setup && mvn install -DskipTests --no-transfer-progress
+artifacts:
+  - matsim-aws-setup/target/matsim-aws-setup-*.jar

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,4 @@
 jdk:
   - openjdk21
-build:
-  - cd matsim-aws-setup && mvn install -DskipTests --no-transfer-progress
-artifacts:
-  - matsim-aws-setup/target/matsim-aws-setup-*.jar
+install:
+  - mvn install -f matsim-aws-setup/pom.xml -DskipTests --no-transfer-progress

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
@@ -5,6 +5,12 @@ import software.amazon.awscdk.App;
 import software.amazon.awscdk.Environment;
 import software.amazon.awscdk.StackProps;
 import software.amazon.awscdk.services.s3.IBucket;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
+import software.amazon.awssdk.core.exception.SdkException;
+
+import java.util.List;
 
 public class Run {
 
@@ -23,8 +29,32 @@ public class Run {
                 .build();
     }
 
+    private static void validateBucketsDoNotExist() {
+        String account = System.getenv("AWS_ACCOUNT");
+        String region = System.getenv("REGION");
+        List<String> bucketNames = List.of(S3Stack.inputBucketName(account), S3Stack.outputBucketName(account));
+        try (S3Client s3 = S3Client.builder().region(Region.of(region)).build()) {
+            for (String bucketName : bucketNames) {
+                try {
+                    s3.headBucket(r -> r.bucket(bucketName));
+                    throw new IllegalStateException(
+                            "Bucket '" + bucketName + "' already exists in account " + account + ". " +
+                            "Set USE_EXISTING_BUCKETS=true in environment.env to use the existing buckets.");
+                } catch (NoSuchBucketException ignored) {
+                    // bucket does not exist — safe to create
+                } catch (SdkException ignored) {
+                    // cannot verify (e.g. insufficient permissions) — skip check and let CloudFormation handle it
+                }
+            }
+        }
+    }
+
 
     public static void main(final String[] args) {
+
+        if (!USE_EXISTING_BUCKETS) {
+            validateBucketsDoNotExist();
+        }
 
         App app = new App();
 

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
@@ -5,12 +5,6 @@ import software.amazon.awscdk.App;
 import software.amazon.awscdk.Environment;
 import software.amazon.awscdk.StackProps;
 import software.amazon.awscdk.services.s3.IBucket;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
-import software.amazon.awssdk.core.exception.SdkException;
-
-import java.util.List;
 
 public class Run {
 
@@ -18,7 +12,6 @@ public class Run {
 
     private static final String IAM_POLICY_CSV = System.getenv("IAM_POLICY_CSV");
     private static final boolean DEPLOY_SLACK_LAMBDA = Boolean.parseBoolean(System.getenv("DEPLOY_SLACK_LAMBDA"));
-    private static final boolean USE_EXISTING_BUCKETS = Boolean.parseBoolean(System.getenv("USE_EXISTING_BUCKETS"));
     private static final String SLACK_HOOK_URL = System.getenv("SLACK_HOOK_URL");
     private static final String SLACK_CHANNEL_NAME = System.getenv("SLACK_CHANNEL_NAME");
 
@@ -30,38 +23,13 @@ public class Run {
                 .build();
     }
 
-    private static void validateBucketsDoNotExist() {
-        String account = System.getenv("AWS_ACCOUNT");
-        String region = System.getenv("REGION");
-        List<String> bucketNames = List.of(S3Stack.inputBucketName(account), S3Stack.outputBucketName(account));
-        try (S3Client s3 = S3Client.builder().region(Region.of(region)).build()) {
-            for (String bucketName : bucketNames) {
-                try {
-                    s3.headBucket(r -> r.bucket(bucketName));
-                    throw new IllegalStateException(
-                            "Bucket '" + bucketName + "' already exists in account " + account + ". " +
-                            "Set USE_EXISTING_BUCKETS=true in environment.env to use the existing buckets.");
-                } catch (NoSuchBucketException ignored) {
-                    // bucket does not exist — safe to create
-                } catch (SdkException ignored) {
-                    // cannot verify (e.g. insufficient permissions) — skip check and let CloudFormation handle it
-                }
-            }
-        }
-    }
-
-
     public static void main(final String[] args) {
-
-        if (!USE_EXISTING_BUCKETS) {
-            validateBucketsDoNotExist();
-        }
 
         App app = new App();
 
         StackProps stackProps = StackProps.builder().env(ENV).build();
         VPCStack vpcStack = new VPCStack(app, "VpcStack", stackProps);
-        S3Stack s3Stack = new S3Stack(app, "S3Stack", stackProps, USE_EXISTING_BUCKETS);
+        S3Stack s3Stack = new S3Stack(app, "S3Stack", stackProps);
 
         IBucket inputBucket = s3Stack.getInputBucket();
         IBucket outputBucket = s3Stack.getOutputBucket();

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
@@ -45,7 +45,7 @@ public class Run {
         new ECRStack(app, "ECRStack", stackProps);
         new BatchStack(app, "BatchStack", stackProps, vpcStack.getVpc());
         if(DEPLOY_SLACK_LAMBDA) {
-            new JobNotificationLambdaStack(app, "JobNotificationStack", stackProps, SLACK_HOOK_URL, SLACK_CHANNEL_NAME);
+            new JobNotificationStack(app, "JobNotificationStack", stackProps, SLACK_HOOK_URL, SLACK_CHANNEL_NAME);
         }
         app.synth();
     }

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
@@ -11,6 +11,7 @@ public class Run {
     private static final Environment ENV = makeEnv(System.getenv("AWS_ACCOUNT"), System.getenv("REGION"));
 
     private static final boolean DEPLOY_SLACK_LAMBDA = Boolean.parseBoolean(System.getenv("DEPLOY_SLACK_LAMBDA"));
+    private static final boolean USE_EXISTING_BUCKETS = Boolean.parseBoolean(System.getenv("USE_EXISTING_BUCKETS"));
     private static final String SLACK_HOOK_URL = System.getenv("SLACK_HOOK_URL");
     private static final String SLACK_CHANNEL_NAME = System.getenv("SLACK_CHANNEL_NAME");
 
@@ -29,7 +30,7 @@ public class Run {
 
         StackProps stackProps = StackProps.builder().env(ENV).build();
         VPCStack vpcStack = new VPCStack(app, "VpcStack", stackProps);
-        S3Stack s3Stack = new S3Stack(app, "S3Stack", stackProps);
+        S3Stack s3Stack = new S3Stack(app, "S3Stack", stackProps, USE_EXISTING_BUCKETS);
 
         IBucket inputBucket = s3Stack.getInputBucket();
         IBucket outputBucket = s3Stack.getOutputBucket();

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
@@ -2,10 +2,15 @@ package io.moia.aws.infra.stacks;
 
 import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.s3.*;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.constructs.Construct;
 import software.constructs.Node;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 
@@ -29,6 +34,9 @@ public class S3Stack extends Stack {
 //            boolean useExisting = true;
 
             String account = stackProps.getEnv().getAccount();
+            if (!useExisting) {
+                S3Stack.validateBucketsDoNotExist(account, stackProps.getEnv().getRegion());
+            }
             if (useExisting) {
                 inputBucket = Bucket.fromBucketName(this, "InputBucket", inputBucketName(account));
                 outputBucket = Bucket.fromBucketName(this, "OutputBucket", outputBucketName(account));
@@ -122,6 +130,24 @@ public class S3Stack extends Stack {
                 .removalPolicy(RemovalPolicy.RETAIN)
                 .lifecycleRules(Arrays.asList(rule1, rule2))
                 .build();
+    }
+
+    static void validateBucketsDoNotExist(String account, String region) {
+        List<String> bucketNames = List.of(inputBucketName(account), outputBucketName(account));
+        try (S3Client s3 = S3Client.builder().region(Region.of(region)).build()) {
+            for (String bucketName : bucketNames) {
+                try {
+                    s3.headBucket(r -> r.bucket(bucketName));
+                    throw new IllegalStateException(
+                            "Bucket '" + bucketName + "' already exists in account " + account + ". " +
+                            "Set USE_EXISTING_BUCKETS=true in environment.env to use the existing buckets.");
+                } catch (NoSuchBucketException ignored) {
+                    // bucket does not exist — safe to create
+                } catch (SdkException ignored) {
+                    // cannot verify (e.g. insufficient permissions) — skip check and let CloudFormation handle it
+                }
+            }
+        }
     }
 
     public IBucket getInputBucket() {

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
@@ -3,8 +3,10 @@ package io.moia.aws.infra.stacks;
 import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.s3.*;
 import software.constructs.Construct;
+import software.constructs.Node;
 
 import java.util.Arrays;
+import java.util.Map;
 
 
 public class S3Stack extends Stack {
@@ -78,10 +80,22 @@ public class S3Stack extends Stack {
                 .abortIncompleteMultipartUploadAfter(Duration.days(7))
                 .build();
 
+        Object retentionCtx = Node.of(scope).tryGetContext("failedRunRetentionDays");
+        int retentionDays = retentionCtx != null
+                ? Integer.parseInt(retentionCtx.toString())
+                : 7;
+
+        LifecycleRule rule3 = LifecycleRule.builder()
+                .id("DeleteFailedSimulationOutputs")
+                .enabled(true)
+                .tagFilters(Map.of("SimulationStatus", "failed"))
+                .expiration(Duration.days(retentionDays))
+                .build();
+
         return Bucket.Builder.create(scope, "OutputBucket")
                 .bucketName(bucketName)
                 .removalPolicy(RemovalPolicy.RETAIN)
-                .lifecycleRules(Arrays.asList(rule1, rule2))
+                .lifecycleRules(Arrays.asList(rule1, rule2, rule3))
                 .build();
     }
 

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
@@ -2,15 +2,10 @@ package io.moia.aws.infra.stacks;
 
 import software.amazon.awscdk.*;
 import software.amazon.awscdk.services.s3.*;
-import software.amazon.awssdk.core.exception.SdkException;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.constructs.Construct;
 import software.constructs.Node;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 
@@ -34,9 +29,6 @@ public class S3Stack extends Stack {
 //            boolean useExisting = true;
 
             String account = stackProps.getEnv().getAccount();
-            if (!useExisting) {
-                S3Stack.validateBucketsDoNotExist(account, stackProps.getEnv().getRegion());
-            }
             if (useExisting) {
                 inputBucket = Bucket.fromBucketName(this, "InputBucket", inputBucketName(account));
                 outputBucket = Bucket.fromBucketName(this, "OutputBucket", outputBucketName(account));
@@ -130,24 +122,6 @@ public class S3Stack extends Stack {
                 .removalPolicy(RemovalPolicy.RETAIN)
                 .lifecycleRules(Arrays.asList(rule1, rule2))
                 .build();
-    }
-
-    static void validateBucketsDoNotExist(String account, String region) {
-        List<String> bucketNames = List.of(inputBucketName(account), outputBucketName(account));
-        try (S3Client s3 = S3Client.builder().region(Region.of(region)).build()) {
-            for (String bucketName : bucketNames) {
-                try {
-                    s3.headBucket(r -> r.bucket(bucketName));
-                    throw new IllegalStateException(
-                            "Bucket '" + bucketName + "' already exists in account " + account + ". " +
-                            "Set USE_EXISTING_BUCKETS=true in environment.env to use the existing buckets.");
-                } catch (NoSuchBucketException ignored) {
-                    // bucket does not exist — safe to create
-                } catch (SdkException ignored) {
-                    // cannot verify (e.g. insufficient permissions) — skip check and let CloudFormation handle it
-                }
-            }
-        }
     }
 
     public IBucket getInputBucket() {

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/S3Stack.java
@@ -14,19 +14,16 @@ public class S3Stack extends Stack {
     private static IBucket inputBucket;
     private static IBucket outputBucket;
 
-    public S3Stack(Construct scope, final String name, StackProps stackProps) {
+    public S3Stack(Construct scope, final String name, StackProps stackProps, boolean useExistingBuckets) {
         super(scope, name, stackProps);
-        new S3Construct(this, name, stackProps);
+        new S3Construct(this, name, stackProps, useExistingBuckets);
     }
 
     private static class S3Construct extends Construct {
 
 
-        S3Construct(final Construct parent, final String name, StackProps stackProps) {
+        S3Construct(final Construct parent, final String name, StackProps stackProps, boolean useExisting) {
             super(parent, name);
-
-          //  boolean useExisting = Boolean.parseBoolean((String) this.getNode().tryGetContext("useExistingBuckets"));
-            boolean useExisting = true;
 
             String account = stackProps.getEnv().getAccount();
             if (useExisting) {

--- a/matsim-aws-setup/src/main/java/io/moia/aws/run/BatchJobUtils.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/run/BatchJobUtils.java
@@ -135,6 +135,8 @@ public class BatchJobUtils {
 
         private JobRecord jobRecord;
         private Region region;
+        private String outputScenario;
+        private String jobName;
 
         private final Collection<KeyValuePair> environment = new HashSet<>();
         private final List<ResourceRequirement> resourceRequirements = new ArrayList<>();
@@ -182,8 +184,20 @@ public class BatchJobUtils {
         }
 
         public JobSubmission outputScenario(String outputScenario){
+            this.outputScenario = outputScenario;
             this.environment.add(KeyValuePair.builder().name("OUTPUT_SCENARIO").value(outputScenario).build());
             return this;
+        }
+
+        /**
+         * Returns the S3 key prefix where this job's output is written: {@code {outputScenario}/{jobName}}.
+         * Only valid after {@link #submit()} has been called.
+         */
+        public String getOutputPath() {
+            if (outputScenario == null || jobName == null) {
+                throw new IllegalStateException("getOutputPath() must be called after submit()");
+            }
+            return outputScenario + "/" + jobName;
         }
 
         public JobSubmission scenario(String scenario){
@@ -201,8 +215,13 @@ public class BatchJobUtils {
             return this;
         }
 
-        public JobSubmission inputDirectories(String directories) {
-            environment.add(KeyValuePair.builder().name("INPUT_DIRECTORIES").value(directories).build());
+        /**
+         * Comma-separated input paths. Relative paths are resolved against {@code JOB_INPUT_BUCKET}.
+         * Full {@code s3://} URIs are used as-is, enabling reads from any bucket (e.g. the output bucket).
+         * A trailing slash forces a directory sync; otherwise the container auto-detects file vs. prefix.
+         */
+        public JobSubmission inputPaths(String paths) {
+            environment.add(KeyValuePair.builder().name("INPUT_PATHS").value(paths).build());
             return this;
         }
 
@@ -237,7 +256,7 @@ public class BatchJobUtils {
             DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
             LocalDateTime now = LocalDateTime.now();
 
-            String jobName = dtf.format(now).concat("-").concat(jobRecord.jobName());
+            jobName = dtf.format(now).concat("-").concat(jobRecord.jobName());
 
             environment.add(KeyValuePair.builder().name("JOB_NAME").value(jobName).build());
 

--- a/matsim-aws-setup/src/main/java/io/moia/aws/run/BatchJobUtils.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/run/BatchJobUtils.java
@@ -201,6 +201,16 @@ public class BatchJobUtils {
             return this;
         }
 
+        public JobSubmission inputDirectories(String directories) {
+            environment.add(KeyValuePair.builder().name("INPUT_DIRECTORIES").value(directories).build());
+            return this;
+        }
+
+        public JobSubmission environment(String name, String value) {
+            environment.add(KeyValuePair.builder().name(name).value(value).build());
+            return this;
+        }
+
         public JobSubmission dependsOn(JobDependency... jobDependencies) {
 			Collections.addAll(this.jobDependencies, jobDependencies);
             return this;


### PR DESCRIPTION
- in addition to directories in the input bucket, allow to specify specific files as input, either as a path in the input bucket or as a s3 URL. This reduces data download at the start of a run, and allows to access output of previous runs to use as input to subsequent runs
- check the return code of the java job, and mark the files for automatic deletion by s3 in case of failure, after a configurable retention period
- add a metadata file to each output directory, with important information for traceability.
- add a check that S3 buckets do not already exist before attempting to create them