### PR TITLE
make the IDs of the VPC stack stable

### DIFF
--- a/matsim-aws-setup/pom.xml
+++ b/matsim-aws-setup/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.moia</groupId>
     <artifactId>matsim-aws-setup</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <name>matsim-aws-setup</name>
     <description>AWS infrastructure-as-code and job submission utilities for running MATSim on AWS Batch</description>

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
@@ -36,7 +36,7 @@ public class Run {
 
         new IAMStack(app, "IAMStack", stackProps, inputBucket, outputBucket, PolicyStatementParser.parse(IAM_POLICY_CSV));
         new ECRStack(app, "ECRStack", stackProps);
-        new BatchStack(app, "BatchStack", stackProps, vpcStack.getVpc());
+        new BatchStack(app, "BatchStack", stackProps, vpcStack.getImportableVpc());
         if(DEPLOY_SLACK_LAMBDA) {
             new JobNotificationStack(app, "JobNotificationStack", stackProps, SLACK_HOOK_URL, SLACK_CHANNEL_NAME);
         }

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/BatchStack.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/BatchStack.java
@@ -22,7 +22,7 @@ public class BatchStack extends Stack {
 
     public static final String MATSIM_JOB_QUEUE_ON_DEMAND = "MATSimJobQueueOnDemand";
 
-    public BatchStack(Construct scope, final String name, StackProps stackProps, Vpc vpc) {
+    public BatchStack(Construct scope, final String name, StackProps stackProps, IVpc vpc) {
         super(scope, name, stackProps);
         new BatchConstruct(this, name, vpc);
     }

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/VPCStack.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/VPCStack.java
@@ -1,16 +1,34 @@
 package io.moia.aws.infra.stacks;
 
 import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.Fn;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
 import software.amazon.awscdk.services.ec2.*;
 import software.constructs.Construct;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class VPCStack extends Stack {
 
     private static Vpc matsimVPC;
+
+    // Stable CloudFormation export name for the VPC ID.
+    // Intentionally unchanged from the existing export so any external consumers
+    // that already reference "mainVpcId" continue to work.
+    public static final String EXPORT_VPC_ID = "mainVpcId";
+
+    // Stable export name patterns for private subnet IDs and AZs.
+    // Index matches the order returned by Vpc.getPrivateSubnets().
+    private static String exportPrivateSubnetId(int index) {
+        return "matsim-private-subnet-id-" + index;
+    }
+
+    private static String exportPrivateSubnetAz(int index) {
+        return "matsim-private-subnet-az-" + index;
+    }
 
     public VPCStack(Construct scope, final String name, StackProps stackProps) {
         super(scope, name, stackProps);
@@ -19,6 +37,32 @@ public class VPCStack extends Stack {
 
     public Vpc getVpc() {
         return matsimVPC;
+    }
+
+    /**
+     * Returns an IVpc whose subnet IDs and AZs are resolved via Fn.importValue()
+     * on the stable CloudFormation export names declared by this stack.
+     *
+     * Use this method instead of getVpc() when passing the VPC to another stack.
+     * Fn.importValue() tokens do not trigger implicit CDK cross-stack exports,
+     * so the export names remain stable across CDK version upgrades.
+     */
+    public IVpc getImportableVpc() {
+        int subnetCount = matsimVPC.getPrivateSubnets().size();
+
+        List<String> privateSubnetIds = new ArrayList<>();
+        List<String> availabilityZones = new ArrayList<>();
+        for (int i = 0; i < subnetCount; i++) {
+            privateSubnetIds.add(Fn.importValue(exportPrivateSubnetId(i)));
+            availabilityZones.add(Fn.importValue(exportPrivateSubnetAz(i)));
+        }
+
+        return Vpc.fromVpcAttributes(this, "ImportableVpc",
+                VpcAttributes.builder()
+                        .vpcId(Fn.importValue(EXPORT_VPC_ID))
+                        .availabilityZones(availabilityZones)
+                        .privateSubnetIds(privateSubnetIds)
+                        .build());
     }
 
     private static class VPCConstruct extends Construct {
@@ -34,22 +78,38 @@ public class VPCStack extends Stack {
             VpcProps vpcProps = VpcProps.builder().natGateways(1).gatewayEndpoints(s3).build();
             matsimVPC = new Vpc(this, "MatsimVPC", vpcProps);
 
-
             // This is required by PE and making this setting is not possible on the high-level CDK construct
             // because of that we are casting the public subnets to lower level CfnSubnet
             for (ISubnet subnet : matsimVPC.getPublicSubnets()) {
                 ((CfnSubnet) subnet.getNode().getDefaultChild()).setMapPublicIpOnLaunch(false);
             }
 
+            // Existing exports — kept with `this` (inner construct) as parent to
+            // preserve their CloudFormation logical IDs.
             CfnOutput.Builder.create(this, "mainVpcId")
                     .value(matsimVPC.getVpcId())
-                    .exportName("mainVpcId")
+                    .exportName(EXPORT_VPC_ID)
                     .build();
 
             CfnOutput.Builder.create(this, "mainVpcArn")
                     .value(matsimVPC.getVpcArn())
                     .exportName("mainVpcArn")
                     .build();
+
+            // New stable private subnet exports, attached to `parent` (the VPCStack)
+            // so their logical IDs are simple and predictable.
+            List<? extends ISubnet> privateSubnets = matsimVPC.getPrivateSubnets();
+            for (int i = 0; i < privateSubnets.size(); i++) {
+                ISubnet subnet = privateSubnets.get(i);
+                CfnOutput.Builder.create(parent, "privateSubnetId" + i)
+                        .value(subnet.getSubnetId())
+                        .exportName(exportPrivateSubnetId(i))
+                        .build();
+                CfnOutput.Builder.create(parent, "privateSubnetAz" + i)
+                        .value(subnet.getAvailabilityZone())
+                        .exportName(exportPrivateSubnetAz(i))
+                        .build();
+            }
         }
     }
 }


### PR DESCRIPTION
I had issues when redeploying on top of an existing deployment, because
the IDs are not stable when using the CDK defaults.