### PR TITLE
Fix batch dependson

### DIFF
--- a/matsim-aws-setup/pom.xml
+++ b/matsim-aws-setup/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.moia</groupId>
     <artifactId>matsim-aws-setup</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>matsim-aws-setup</name>
     <description>AWS infrastructure-as-code and job submission utilities for running MATSim on AWS Batch</description>

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
@@ -8,14 +8,7 @@ import software.amazon.awscdk.services.s3.IBucket;
 
 public class Run {
 
-    private static final Environment ENV = makeEnv(requireEnv("AWS_ACCOUNT"), requireEnv("REGION"));
-
-    private static final String IAM_POLICY_CSV = System.getenv("IAM_POLICY_CSV");
-    private static final boolean DEPLOY_SLACK_LAMBDA = Boolean.parseBoolean(System.getenv("DEPLOY_SLACK_LAMBDA"));
-    private static final String SLACK_HOOK_URL = System.getenv("SLACK_HOOK_URL");
-    private static final String SLACK_CHANNEL_NAME = System.getenv("SLACK_CHANNEL_NAME");
-
-    private static String requireEnv(String name) {
+    static String requireEnv(String name) {
         String value = System.getenv(name);
         if (value == null || value.isBlank()) {
             throw new IllegalStateException("Required environment variable not set: " + name);
@@ -23,7 +16,6 @@ public class Run {
         return value;
     }
 
-    // Helper method to build an environment
     static Environment makeEnv(String account, String region) {
         return Environment.builder()
                 .account(account)
@@ -31,24 +23,38 @@ public class Run {
                 .build();
     }
 
-    public static void main(final String[] args) {
-
+    static App buildApp(String account, String region, String iamPolicyCsv, boolean deploySlackLambda,
+                        String slackHookUrl, String slackChannelName) {
         App app = new App();
+        StackProps stackProps = StackProps.builder().env(makeEnv(account, region)).build();
 
-        StackProps stackProps = StackProps.builder().env(ENV).build();
         VPCStack vpcStack = new VPCStack(app, "VpcStack", stackProps);
         S3Stack s3Stack = new S3Stack(app, "S3Stack", stackProps);
 
         IBucket inputBucket = s3Stack.getInputBucket();
         IBucket outputBucket = s3Stack.getOutputBucket();
 
-        new IAMStack(app, "IAMStack", stackProps, inputBucket, outputBucket, PolicyStatementParser.parse(IAM_POLICY_CSV));
+        new IAMStack(app, "IAMStack", stackProps, inputBucket, outputBucket, PolicyStatementParser.parse(iamPolicyCsv));
         new ECRStack(app, "ECRStack", stackProps);
-        new BatchStack(app, "BatchStack", stackProps, vpcStack.getImportableVpc());
-        if(DEPLOY_SLACK_LAMBDA) {
-            new JobNotificationStack(app, "JobNotificationStack", stackProps, SLACK_HOOK_URL, SLACK_CHANNEL_NAME);
+        BatchStack batchStack = new BatchStack(app, "BatchStack", stackProps, vpcStack.getImportableVpc());
+        // Fn.importValue() tokens are opaque to CDK's dependency graph, so we declare
+        // the dependency explicitly to ensure VpcStack is fully deployed before BatchStack.
+        batchStack.addDependency(vpcStack);
+        if (deploySlackLambda) {
+            new JobNotificationStack(app, "JobNotificationStack", stackProps, slackHookUrl, slackChannelName);
         }
-        app.synth();
+        return app;
+    }
 
+    public static void main(final String[] args) {
+        App app = buildApp(
+                requireEnv("AWS_ACCOUNT"),
+                requireEnv("REGION"),
+                System.getenv("IAM_POLICY_CSV"),
+                Boolean.parseBoolean(System.getenv("DEPLOY_SLACK_LAMBDA")),
+                System.getenv("SLACK_HOOK_URL"),
+                System.getenv("SLACK_CHANNEL_NAME")
+        );
+        app.synth();
     }
 }

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/Run.java
@@ -8,12 +8,20 @@ import software.amazon.awscdk.services.s3.IBucket;
 
 public class Run {
 
-    private static final Environment ENV = makeEnv(System.getenv("AWS_ACCOUNT"), System.getenv("REGION"));
+    private static final Environment ENV = makeEnv(requireEnv("AWS_ACCOUNT"), requireEnv("REGION"));
 
     private static final String IAM_POLICY_CSV = System.getenv("IAM_POLICY_CSV");
     private static final boolean DEPLOY_SLACK_LAMBDA = Boolean.parseBoolean(System.getenv("DEPLOY_SLACK_LAMBDA"));
     private static final String SLACK_HOOK_URL = System.getenv("SLACK_HOOK_URL");
     private static final String SLACK_CHANNEL_NAME = System.getenv("SLACK_CHANNEL_NAME");
+
+    private static String requireEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Required environment variable not set: " + name);
+        }
+        return value;
+    }
 
     // Helper method to build an environment
     static Environment makeEnv(String account, String region) {

--- a/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/VPCStack.java
+++ b/matsim-aws-setup/src/main/java/io/moia/aws/infra/stacks/VPCStack.java
@@ -22,11 +22,11 @@ public class VPCStack extends Stack {
 
     // Stable export name patterns for private subnet IDs and AZs.
     // Index matches the order returned by Vpc.getPrivateSubnets().
-    private static String exportPrivateSubnetId(int index) {
+    public static String exportPrivateSubnetId(int index) {
         return "matsim-private-subnet-id-" + index;
     }
 
-    private static String exportPrivateSubnetAz(int index) {
+    public static String exportPrivateSubnetAz(int index) {
         return "matsim-private-subnet-az-" + index;
     }
 

--- a/matsim-aws-setup/src/test/java/io/moia/aws/infra/RunTest.java
+++ b/matsim-aws-setup/src/test/java/io/moia/aws/infra/RunTest.java
@@ -1,0 +1,100 @@
+package io.moia.aws.infra;
+
+import io.moia.aws.infra.stacks.BatchStack;
+import io.moia.aws.infra.stacks.VPCStack;
+import org.junit.jupiter.api.Test;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.assertions.Match;
+import software.amazon.awscdk.assertions.Template;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RunTest {
+
+    private static final String TEST_ACCOUNT = "123456789012";
+    private static final String TEST_REGION = "eu-central-1";
+
+    private static App buildTestApp() {
+        return Run.buildApp(TEST_ACCOUNT, TEST_REGION, null, false, null, null);
+    }
+
+    private static VPCStack vpcStack(App app) {
+        return (VPCStack) app.getNode().findChild("VpcStack");
+    }
+
+    private static BatchStack batchStack(App app) {
+        return (BatchStack) app.getNode().findChild("BatchStack");
+    }
+
+    // Without a fail-fast guard, a missing REGION env var silently produces an environment-agnostic
+    // CDK app, causing Fn::GetAZs tokens in subnet AZs instead of hardcoded strings (see below).
+    @Test
+    void requireEnv_throwsWhenMissing() {
+        assertThrows(IllegalStateException.class, () -> Run.requireEnv("__MISSING_VAR_XYZ__"));
+    }
+
+    @Test
+    void requireEnv_returnsValueWhenSet() {
+        assertDoesNotThrow(() -> Run.requireEnv("PATH")); // PATH is always present
+    }
+
+    // BatchStack imports subnet IDs and AZs from VpcStack via Fn::ImportValue. Those export names
+    // are referenced by name in deployed stacks: renaming or removing them would break any existing
+    // deployment that still has the old BatchStack template in CloudFormation.
+    @Test
+    void vpcStack_exportsAllPrivateSubnetIds() {
+        VPCStack vpc = vpcStack(buildTestApp());
+        Template template = Template.fromStack(vpc);
+        int count = vpc.getVpc().getPrivateSubnets().size();
+
+        for (int i = 0; i < count; i++) {
+            template.hasOutput("privateSubnetId" + i,
+                    Map.of("Export", Map.of("Name", VPCStack.exportPrivateSubnetId(i))));
+        }
+    }
+
+    @Test
+    void vpcStack_exportsAllPrivateSubnetAzs() {
+        VPCStack vpc = vpcStack(buildTestApp());
+        Template template = Template.fromStack(vpc);
+        int count = vpc.getVpc().getPrivateSubnets().size();
+
+        for (int i = 0; i < count; i++) {
+            template.hasOutput("privateSubnetAz" + i,
+                    Map.of("Export", Map.of("Name", VPCStack.exportPrivateSubnetAz(i))));
+        }
+    }
+
+    // When REGION is null, CDK produces an environment-agnostic app and cannot resolve AZs at synth
+    // time. It falls back to Fn::GetAZs intrinsics, which CloudFormation resolves at deploy time in
+    // alphabetical order. If the account's actual AZ order differs, CloudFormation sees a change to
+    // the subnet AvailabilityZone property — a replace-only field — and tries to recreate all
+    // subnets, failing because the old ones still exist with the same CIDRs.
+    @Test
+    void vpcStack_subnetAzsAreHardcodedStrings() {
+        Template template = Template.fromStack(vpcStack(buildTestApp()));
+
+        template.resourcePropertiesCountIs("AWS::EC2::Subnet",
+                Map.of("AvailabilityZone", Map.of("Fn::Select", Match.anyValue())), 0);
+        template.resourcePropertiesCountIs("AWS::EC2::Subnet",
+                Map.of("AvailabilityZone", Map.of("Fn::GetAZs", Match.anyValue())), 0);
+    }
+
+    // BatchStack imports VPC subnet IDs via Fn::ImportValue, which is opaque to CDK's dependency
+    // graph. Without an explicit addDependency(), CDK deploys VpcStack and BatchStack in parallel.
+    // On a first deploy BatchStack can start before VpcStack has created its exports, causing
+    // "No export named matsim-private-subnet-id-N found" and a BatchStack rollback.
+    @Test
+    void batchStack_dependsOnVpcStack() {
+        App app = buildTestApp();
+        Stack vpc = vpcStack(app);
+        Stack batch = batchStack(app);
+
+        boolean dependsOnVpc = batch.getDependencies().stream()
+                .anyMatch(dep -> dep.getStackName().equals(vpc.getStackName()));
+        assertTrue(dependsOnVpc, "BatchStack must declare an explicit dependency on VpcStack");
+    }
+}


### PR DESCRIPTION
A previous PR fixed the problem that the VPC components had IDs that were automatically created by CDK, which were thus unstable and created issues when re-deploying an existing infrastructure.

This unfortunately broke deploying in an empty account, because CDK did not represent the dependency of BatchStack on VpcStack anymore, leading to both being deployed in parallel - although VpcStack is required to be deployed for BatchStack deployment to succeed.

This PR solved this issue by explicitly tagging this dependency, and adding unit tests of the recently included fixes.