### PR TITLE
Bugfix: return status

### DIFF
--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -195,3 +195,5 @@ while [ "${MATSIM_DONE_SEMAPHORE}" -nt "${SYNC_SEMAPHORE}" ]; do
   echo "Waiting for until sync to S3 has completed. Checking every ${SLEEP_FOR} seconds..."
   sleep ${SLEEP_FOR}
 done
+
+exit $RET

--- a/matsim-aws-setup/pom.xml
+++ b/matsim-aws-setup/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.moia</groupId>
     <artifactId>matsim-aws-setup</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <name>matsim-aws-setup</name>
     <description>AWS infrastructure-as-code and job submission utilities for running MATSim on AWS Batch</description>


### PR DESCRIPTION
Return status from the matsim run was not returned, leading to failed runs being marked as succeeded in AWS Batch